### PR TITLE
Smaller docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,8 @@ ARG default_env_location
 ARG launcher_location
 
 # APK updates
-RUN apk update
-RUN apk add ca-certificates
+RUN apk --no-cache add ca-certificates wget gettext libintl bash python
 RUN update-ca-certificates
-RUN apk add wget gettext libintl bash python
 
 # Download the server
 RUN wget $download_url -O /server.jar


### PR DESCRIPTION
`--no-cache` is best to use in docker images:
> As of Alpine Linux 3.3 there exists a new --no-cache option for apk. It allows users to install packages with an index that is updated and used on-the-fly and not cached locally
> https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md

It saves a whopping 1.3Mb! :laughing:

If you were to change the launch script to work in the standard shell, you could drop bash and save a good chunk more.