### PR TITLE
Fix build.py erroring

### DIFF
--- a/build.py
+++ b/build.py
@@ -57,6 +57,6 @@ for category,versions in categories.items():
 
 
 # Output tags to file
-with open(sys.argv[1]) as f, open('tags.txt', 'w') as out:
+with open('tags.txt', 'w') as out:
     for tag in tags:
         out.write(tag+'\n')


### PR DESCRIPTION
build.py errored when I ran it. I couldn't see the reason for the `argv as f` bit, and taking it out fixed it; but I don't know if it was meant for something...?